### PR TITLE
Add ignore case for ReviewerID in SurveyAssigment request

### DIFF
--- a/src/main/java/fr/insee/edtmanagement/repository/SurveyAssigmentRepository.java
+++ b/src/main/java/fr/insee/edtmanagement/repository/SurveyAssigmentRepository.java
@@ -16,7 +16,7 @@ public interface SurveyAssigmentRepository extends CrudRepository<SurveyAssigmen
 	Optional<SurveyAssigment> findByInterviewerIdIgnoreCaseAndSurveyUnitIdAndCampaignId(String interviewerId, String surveyUnitId,
 			String campaignId);
 
-	Optional<SurveyAssigment> findByReviewerIdAndSurveyUnitIdAndCampaignId(String reviewerId, String surveyUnitId,
+	Optional<SurveyAssigment> findByReviewerIdIgnoreCaseAndSurveyUnitIdAndCampaignId(String reviewerId, String surveyUnitId,
 			String campaignId);
 	
 	Optional<List<SurveyAssigment>> findByReviewerIdIgnoreCase(String userId);

--- a/src/main/java/fr/insee/edtmanagement/service/AuthorizationService.java
+++ b/src/main/java/fr/insee/edtmanagement/service/AuthorizationService.java
@@ -37,6 +37,6 @@ public class AuthorizationService {
 
 	private boolean checkReviewerHabilitation(String surveyId, String campaignId, String userId) {
 		return surveyAssigmentRepository
-				.findByReviewerIdAndSurveyUnitIdAndCampaignId(userId, surveyId, campaignId).isPresent();
+				.findByReviewerIdIgnoreCaseAndSurveyUnitIdAndCampaignId(userId, surveyId, campaignId).isPresent();          
 	}
 }


### PR DESCRIPTION
Adding ignore case for reviewerId enable to deal with lowercase or uppercase reviewer identifier sent by Queen Back Office