### PR TITLE
Workaround to allow reviewers to use some PUT endpoints from Queen BO

### DIFF
--- a/src/main/java/fr/insee/edtmanagement/controller/HabilitationController.java
+++ b/src/main/java/fr/insee/edtmanagement/controller/HabilitationController.java
@@ -28,9 +28,15 @@ public class HabilitationController {
 			@RequestParam(value = "campaign", required = true) String campaignId,
 			@RequestParam(value = "idep", required = true) String userId) {
 		
+		//Queen Back Office doesnt send the role when it concerns an INTERVIEWER
+		if (expectedRole == null) {
+			expectedRole = Constants.INTERVIEWER;
+		}
+		
 		log.info("Checking Habilitation for survey {} in campaign  {} with role {} as {} ",surveyId,campaignId,expectedRole,userId);
 
 		HabilitationDto habilitation = new HabilitationDto();
+		
 		boolean kAutorisation= authorizationService.isAuthorized(surveyId, expectedRole, campaignId, userId);	
 		habilitation.setHabilitated(kAutorisation);
 		

--- a/src/main/java/fr/insee/edtmanagement/service/AuthorizationService.java
+++ b/src/main/java/fr/insee/edtmanagement/service/AuthorizationService.java
@@ -1,6 +1,7 @@
 package fr.insee.edtmanagement.service;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
@@ -14,20 +15,33 @@ public class AuthorizationService {
 
 	@Autowired
 	private SurveyAssigmentRepository surveyAssigmentRepository;
+	
+	@Value("${fr.insee.edtmanagement.loose-check-habilitation}")
+	private boolean looseCheckHabilitation;
 
 	@Cacheable("isAuthorized")
 	public Boolean isAuthorized(String surveyId, String expectedRole, String campaignId, String userId) {
 
 		log.debug("Service checking Authorization of userId : {} on surveyId : {} campaign : {} role :  {} ", userId, surveyId,
 				campaignId, expectedRole);
+		
+		if (Constants.INTERVIEWER.equals(expectedRole)) {
+			if (checkInterviewerHabilitation(surveyId, campaignId, userId)) {
+				return true;
+				// Workaround to handle checkHabilitation request from queen BO in case of 
+				// some PUT request made by a reviewer 
+			} else if (looseCheckHabilitation) {
+				log.info("Looking for an habilitation for user {} as a reviewer",userId);
+				return checkReviewerHabilitation(surveyId, campaignId, userId);
+			}
+		}
 
-		if(Constants.REVIEWER.equals(expectedRole)) {
+		if (Constants.REVIEWER.equals(expectedRole)) {
 			return checkReviewerHabilitation(surveyId, campaignId, userId);
 		}
-		
-		// Queen Back Office  doesn t send role when it is an interviewer
-		 return checkInterviewerHabilitation(surveyId, campaignId, userId);
-		
+
+		return false;
+
 	}
 
 	private boolean checkInterviewerHabilitation(String surveyId, String campaignId, String userId) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -24,6 +24,13 @@ spring.security.oauth2.resourceserver.jwt.issuer-uri=${fr.insee.edtmanagement.au
 #Roles
 fr.insee.edtmanagement.admin-role=ZZZ
 
+#(if true) Try to find habilitation for a userId with a role reviewer 
+# event if the request told to match an interviewer
+#cf. Queen Back Office calls  Constants.API_HABILITATION_URL endpoint  
+# with the interviewer role  even when a reviewer tries to use
+# /survey-unit/{id}/data and /survey-unit/{id}/state-data 
+fr.insee.edtmanagement.loose-check-habilitation=true
+
 #Cors
 fr.insee.edtmanagement.corsAllowedOrigins=*
 


### PR DESCRIPTION
When a reviewer tries to send a PUT request on state-data and data endpoint, Queen Back-Office sends a request to edt-management-api with an interviewer role 
The property _looseCheckHabilitation_ enables the edt-management-api to check if the userId sent in this case is known as a reviewer for the same surveyId and campaignId.